### PR TITLE
Run with 'python2' instead of 'python'

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys


### PR DESCRIPTION
PEP suggests using 'python' for scripts that work with both Python 2 and Python 3, 'python2' for scripts that work only in Python 2 and 'python3' for scripts that work only in Python 3.
